### PR TITLE
Basic support for reading incidents (GET requests only).

### DIFF
--- a/Cachet.NET.Example/Program.cs
+++ b/Cachet.NET.Example/Program.cs
@@ -10,7 +10,7 @@
         /// </summary>
         internal static void Main()
         {
-            var Cachet = new Cachet("https://status.gobelinland.fr/api/v1/", "");
+            var Cachet = new Cachet("https://demo.cachethq.io/api/v1/", "");
 
             Console.WriteLine("Ping : " + Cachet.Ping() + ".");
 
@@ -50,6 +50,16 @@
             foreach (var Group in CompoGr.Groups)
             {
                 Console.WriteLine(" - " + Group.Name);
+            }
+            Console.WriteLine();
+
+            var incidents = Cachet.GetIncidents();
+
+            Console.WriteLine("Incidents : ");
+
+            foreach (var incident in incidents.Incidents)
+            {
+                Console.WriteLine(" - " + incident.Name);
             }
 
             Console.ReadKey(false);

--- a/Cachet.NET/Cachet.NET.csproj
+++ b/Cachet.NET/Cachet.NET.csproj
@@ -49,8 +49,12 @@
     <Compile Include="Responses\ComponentResponse.cs" />
     <Compile Include="Responses\ComponentGroupsResponse.cs" />
     <Compile Include="Responses\ComponentsResponse.cs" />
+    <Compile Include="Responses\IncidentResponse.cs" />
+    <Compile Include="Responses\IncidentsResponse.cs" />
     <Compile Include="Responses\Objects\ComponentGroupObject.cs" />
     <Compile Include="Responses\Objects\ComponentObject.cs" />
+    <Compile Include="Responses\Objects\IncidentObject.cs" />
+    <Compile Include="Responses\Objects\IncidentStatus.cs" />
     <Compile Include="Responses\VersionResponse.cs" />
     <Compile Include="Responses\PingResponse.cs" />
   </ItemGroup>

--- a/Cachet.NET/Cachet.cs
+++ b/Cachet.NET/Cachet.cs
@@ -372,5 +372,112 @@
 
             return null;
         }
+
+        /// <summary>
+        /// Gets a list of incidents from the Cachet API.
+        /// </summary>
+        public IncidentsResponse GetIncidents()
+        {
+            if (this.Initialized == false)
+            {
+                return null;
+            }
+
+            var Request = new RestRequest("incidents");
+            var Response = this.Rest.Get<IncidentsResponse>(Request);
+
+            if (Response.ResponseStatus == ResponseStatus.Completed)
+            {
+                var incidentsResponse = Response.Data;
+
+                if (incidentsResponse != null)
+                {
+                    return incidentsResponse;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the Incidents of the Cachet API.
+        /// </summary>
+        public async Task<IncidentsResponse> GetIncidentsAsync()
+        {
+            if (this.Initialized == false)
+            {
+                return null;
+            }
+
+            var Request = new RestRequest("incidents");
+            var Response = await this.Rest.ExecuteGetTaskAsync<IncidentsResponse>(Request);
+
+            if (Response.ResponseStatus == ResponseStatus.Completed)
+            {
+                var incidentsResponse = Response.Data;
+
+                if (incidentsResponse != null)
+                {
+                    return incidentsResponse;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the specified Incident of the Cachet API.
+        /// </summary>
+        /// <param name="IncidentId">The Incident identifier.</param>
+        public IncidentResponse GetIncident(int IncidentId)
+        {
+            if (this.Initialized == false)
+            {
+                return null;
+            }
+
+            var Request = new RestRequest("incidents/{incidentId}").AddUrlSegment("incidentId", IncidentId);
+            var Response = this.Rest.Get<IncidentResponse>(Request);
+
+            if (Response.ResponseStatus == ResponseStatus.Completed)
+            {
+                var IncidentResponse = Response.Data;
+
+                if (IncidentResponse != null)
+                {
+                    return IncidentResponse;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the specified Incident of the Cachet API.
+        /// </summary>
+        /// <param name="IncidentId">The Incident identifier.</param>s
+        public async Task<IncidentResponse> GetIncidentAsync(int IncidentId)
+        {
+            if (this.Initialized == false)
+            {
+                return null;
+            }
+
+            var Request = new RestRequest("incidents/{incidentId}").AddUrlSegment("incidentId", IncidentId);
+            var Response = await this.Rest.ExecuteGetTaskAsync<IncidentResponse>(Request);
+
+            if (Response.ResponseStatus == ResponseStatus.Completed)
+            {
+                var IncidentResponse = Response.Data;
+
+                if (IncidentResponse != null)
+                {
+                    return IncidentResponse;
+                }
+            }
+
+            return null;
+        }
+
     }
 }

--- a/Cachet.NET/Responses/IncidentResponse.cs
+++ b/Cachet.NET/Responses/IncidentResponse.cs
@@ -1,0 +1,94 @@
+﻿namespace Cachet.NET.Responses
+{
+    using global::Cachet.NET.Responses.Objects;
+
+    using RestSharp.Deserializers;
+
+    public class IncidentResponse
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="MetaObject"/>.
+        /// </summary>
+        public MetaObject Meta
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the Incident.
+        /// </summary>
+        [DeserializeAs(Name = "data")]
+        public IncidentObject Incident
+        {
+            get;
+            set;
+        }
+
+        public class MetaObject
+        {
+            /// <summary>
+            /// Gets or sets the pagination.
+            /// </summary>
+            public PaginationObject Pagination
+            {
+                get;
+                set;
+            }
+
+            public class PaginationObject
+            {
+                public int Total
+                {
+                    get;
+                    set;
+                }
+
+                public int Count
+                {
+                    get;
+                    set;
+                }
+
+                public int PerPage
+                {
+                    get;
+                    set;
+                }
+
+                public int CurrentPage
+                {
+                    get;
+                    set;
+                }
+
+                public int TotalPages
+                {
+                    get;
+                    set;
+                }
+
+                public LinksObject Links
+                {
+                    get;
+                    set;
+                }
+
+                public class LinksObject
+                {
+                    public int NextPage
+                    {
+                        get;
+                        set;
+                    }
+
+                    public int PreviousPage
+                    {
+                        get;
+                        set;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Cachet.NET/Responses/IncidentsResponse.cs
+++ b/Cachet.NET/Responses/IncidentsResponse.cs
@@ -1,0 +1,96 @@
+﻿namespace Cachet.NET.Responses
+{
+    using System.Collections.Generic;
+
+    using global::Cachet.NET.Responses.Objects;
+
+    using RestSharp.Deserializers;
+
+    public class IncidentsResponse
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="MetaObject"/>.
+        /// </summary>
+        public MetaObject Meta
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the Incidents.
+        /// </summary>
+        [DeserializeAs(Name = "data")]
+        public List<IncidentObject> Incidents
+        {
+            get;
+            set;
+        }
+
+        public class MetaObject
+        {
+            /// <summary>
+            /// Gets or sets the pagination.
+            /// </summary>
+            public PaginationObject Pagination
+            {
+                get;
+                set;
+            }
+
+            public class PaginationObject
+            {
+                public int Total
+                {
+                    get;
+                    set;
+                }
+
+                public int Count
+                {
+                    get;
+                    set;
+                }
+
+                public int PerPage
+                {
+                    get;
+                    set;
+                }
+
+                public int CurrentPage
+                {
+                    get;
+                    set;
+                }
+
+                public int TotalPages
+                {
+                    get;
+                    set;
+                }
+
+                public LinksObject Links
+                {
+                    get;
+                    set;
+                }
+
+                public class LinksObject
+                {
+                    public int NextPage
+                    {
+                        get;
+                        set;
+                    }
+
+                    public int PreviousPage
+                    {
+                        get;
+                        set;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Cachet.NET/Responses/Objects/ComponentStatus.cs
+++ b/Cachet.NET/Responses/Objects/ComponentStatus.cs
@@ -1,0 +1,25 @@
+﻿namespace Cachet.NET.Responses.Objects
+{
+    /// <summary>
+    /// Available Component status values from https://docs.cachethq.io/v1.0/docs/component-statuses
+    /// </summary>
+    public enum ComponentStatus : int
+    {
+        /// <summary>
+        /// The component is working.
+        /// </summary>
+        Operational = 1,
+        /// <summary>
+        /// The component is experiencing some slowness.
+        /// </summary>
+        PerformanceIssues = 2,
+        /// <summary>
+        /// The component may not be working for everybody. This could be a geographical issue for example.
+        /// </summary>
+        PartialOutage = 3,
+        /// <summary>
+        /// The component is not working for anybody.
+        /// </summary>
+        MajorOutage = 4
+    }
+}

--- a/Cachet.NET/Responses/Objects/IncidentObject.cs
+++ b/Cachet.NET/Responses/Objects/IncidentObject.cs
@@ -1,0 +1,78 @@
+﻿using RestSharp.Deserializers;
+
+namespace Cachet.NET.Responses.Objects
+{
+    using System;
+
+    public class IncidentObject
+    {
+        [DeserializeAs(Name = "id")]
+        public int Identifier
+        {
+            get;
+            set;
+        }
+
+        [DeserializeAs(Name = "component_id")]
+        public int ComponentId
+        {
+            get;
+            set;
+        }
+
+        public string Name
+        {
+            get;
+            set;
+        }
+
+        public IncidentStatus Status
+        {
+            get;
+            set;
+        }
+        public bool Visible
+        {
+            get;
+            set;
+        }
+
+        public string Message
+        {
+            get;
+            set;
+        }
+
+        public DateTime? ScheduledAt
+        {
+            get;
+            set;
+        }
+
+        public DateTime CreatedAt
+        {
+            get;
+            set;
+        }
+
+        public DateTime UpdatedAt
+        {
+            get;
+            set;
+        }
+
+        public DateTime? DeletedAt
+        {
+            get;
+            set;
+        }
+
+        [DeserializeAs(Name = "human-status")]
+        public string StatusName
+        {
+            get;
+            set;
+        }
+        
+    }
+}

--- a/Cachet.NET/Responses/Objects/IncidentStatus.cs
+++ b/Cachet.NET/Responses/Objects/IncidentStatus.cs
@@ -1,0 +1,29 @@
+﻿namespace Cachet.NET.Responses.Objects
+{
+    /// <summary>
+    /// Available Incident status values from https://docs.cachethq.io/docs/incident-statuses
+    /// </summary>
+    public enum IncidentStatus : int
+    {
+        /// <summary>
+        /// This status is reserved for a scheduled status.
+        /// </summary>
+        Scheduled = 0,
+        /// <summary>
+        /// You have reports of a problem and you're currently looking into them.
+        /// </summary>
+        Investigating = 1,
+        /// <summary>
+        /// You've found the issue and you're working on a fix.
+        /// </summary>
+        Identified = 2,
+        /// <summary>
+        /// You've since deployed a fix and you're currently watching the situation.
+        /// </summary>
+        Watching = 3,
+        /// <summary>
+        /// The fix has worked, you're happy to close the incident.
+        /// </summary>
+        Fixed = 4
+    }
+}


### PR DESCRIPTION
Added basic support for reading incident data from the Cachet API from https://docs.cachethq.io/v1.0/reference#incidents with associated examples.